### PR TITLE
Update Seurat object endpoint logic for downloads

### DIFF
--- a/vignettes/scrnaseq_recipes.Rmd
+++ b/vignettes/scrnaseq_recipes.Rmd
@@ -102,17 +102,20 @@ library(ggridges)
 
 ### Dimensional reduction plot
 
-Using the `Seurat` `DimPlot()` function, make a scatter plot in UMAP space grouping cells by custom annotation set "Default cluster - res. 1.0" (here, we can use one of our custom color palettes that we defined in the Pluto app): 
+Using the `Seurat` `DimPlot()` function, make a scatter plot in UMAP space grouping cells by custom annotation set "Default cluster - res. 0.1" (here, we can use one of our custom color palettes that we defined in the Pluto app): 
 
 ```{r, eval = FALSE}
 DimPlot(so, # the Seurat object
-        reduction = "umap", # could also be "tsne" or "pca"
-        group.by = "default_clusters_res_0_1", # custom annotation set
-        cols = custom_palettes$default_clusters_res_0_1, # custom color palette
-        pt.size = 0.1) + # point size for plotting
-  labs(title = "Default clusters - res. 0.1", # update plot title
-       x = "UMAP 1", # update x-axis label
-       y = "UMAP 2") # update y-axis label
+     reduction = "umap", # could also be "tsne" or "pca"
+     group.by = "default_clusters_res_0_1", # custom annotation set
+     cols = custom_palettes$default_clusters_res_0_1, # custom color palette
+     pt.size = 0.1
+) + # point size for plotting
+     labs(
+          title = "Default clusters - res. 0.1", # update plot title
+          x = "UMAP 1", # update x-axis label
+          y = "UMAP 2"
+     ) # update y-axis label
 ```
 
 <img src="https://cdn.bfldr.com/2Q1IPX6I/at/cv9v8qtfswrqvq69gh58swqb/scrnaseq_vignette_dimplot_group_clusters_example" height="450">
@@ -125,29 +128,35 @@ timepoint_cols <- c("#14b8a6", "#fcd34d", "#ef4444")
 names(timepoint_cols) <- c("24hpf", "36hpf", "48hpf")
 
 DimPlot(so, # the Seurat object
-        reduction = "umap", # could also be "tsne" or "pca"
-        group.by = "timepoint", # available column in our meta.data, from our Pluto sample data
-        cols = timepoint_cols,
-        pt.size = 0.1) + # point size for plotting
-  labs(title = "Timepoint", # update plot title
-       x = "UMAP 1", # update x-axis label
-       y = "UMAP 2") # update y-axis label
+     reduction = "umap", # could also be "tsne" or "pca"
+     group.by = "timepoint", # available column in our meta.data, from our Pluto sample data
+     cols = timepoint_cols,
+     pt.size = 0.1
+) + # point size for plotting
+     labs(
+          title = "Timepoint", # update plot title
+          x = "UMAP 1", # update x-axis label
+          y = "UMAP 2"
+     ) # update y-axis label
 ```
 
 <img src="https://cdn.bfldr.com/2Q1IPX6I/at/fkgzgx77673w98smxnv3vcw/scrnaseq_vignette_dimplot_group_timepoint_example" height="450">
 
-Using the `Seurat` `DimPlot()` function, make a scatter plot in UMAP space grouping cells by custom annotation set "Default cluster - res. 1.0" and splitting cells by timepoint: 
+Using the `Seurat` `DimPlot()` function, make a scatter plot in UMAP space grouping cells by custom annotation set "Default cluster - res. 0.1" and splitting cells by timepoint: 
 
 ```{r, eval = FALSE}
 DimPlot(so, # the Seurat object
-        reduction = "umap", # could also be "tsne" or "pca"
-        group.by = "default_clusters_res_0_1", # custom annotation set
-        cols = custom_palettes$default_clusters_res_0_1, # custom color palette
-        split.by = "timepoint", # custom annotation set
-        pt.size = 0.1) + # point size for plotting
-  labs(title = "Default clusters - res. 0.1", # update plot title
-       x = "UMAP 1", # update x-axis label
-       y = "UMAP 2") # update y-axis label
+     reduction = "umap", # could also be "tsne" or "pca"
+     group.by = "default_clusters_res_0_1", # custom annotation set
+     cols = custom_palettes$default_clusters_res_0_1, # custom color palette
+     split.by = "timepoint", # custom annotation set
+     pt.size = 0.1
+) + # point size for plotting
+     labs(
+          title = "Default clusters - res. 0.1", # update plot title
+          x = "UMAP 1", # update x-axis label
+          y = "UMAP 2"
+     ) # update y-axis label
 ```
 
 <img src="https://cdn.bfldr.com/2Q1IPX6I/at/xwb7wrp834tm2fh9mj9s3gnp/scrnaseq_vignette_dimplot_group_split_example" height="450">
@@ -156,31 +165,37 @@ DimPlot(so, # the Seurat object
 
 #### Violin plot
 
-Using the `Seurat` `VlnPlot()` function, make a violin plot grouping cells by custom annotation set "Default cluster - res. 1.0": 
+Using the `Seurat` `VlnPlot()` function, make a violin plot grouping cells by custom annotation set "Default cluster - res. 0.1": 
 
 ```{r, eval = FALSE}
 VlnPlot(so, # the Seurat object
-        features = c("olig2"), # feature(s) of interest
-        group.by = "default_clusters_res_0_1", # custom annotation set
-        cols = custom_palettes$default_clusters_res_0_1) + # custom color palette
-  labs(title = "Expression of olig2", # update plot title
-       x = "Default clusters - res. 0.1") # update x-axis label
+     features = c("olig2"), # feature(s) of interest
+     group.by = "default_clusters_res_0_1", # custom annotation set
+     cols = custom_palettes$default_clusters_res_0_1
+) + # custom color palette
+     labs(
+          title = "Expression of olig2", # update plot title
+          x = "Default clusters - res. 0.1"
+     ) # update x-axis label
 ```
 
 <img src="https://cdn.bfldr.com/2Q1IPX6I/at/b72z4b34hs68s3c7fksn9s2h/scrnaseq_vignette_vlnplot_example" height="450">
 
 #### Ridge plot
 
-Using the `Seurat` `RidgePlot()` function, make a ridge plot grouping cells by custom annotation set "Default cluster - res. 1.0": 
+Using the `Seurat` `RidgePlot()` function, make a ridge plot grouping cells by custom annotation set "Default cluster - res. 0.1": 
 
 ```{r, eval = FALSE}
 RidgePlot(so, # the Seurat object
-          features = c("olig2"), # feature(s) of interest
-          group.by = "default_clusters_res_0_1", # custom annotation set
-          cols = custom_palettes$default_clusters_res_0_1) + # custom color palette
-  labs(title = "Expression of olig2", # update plot title
-       y = "Default clusters - res. 0.1") + # update x-axis label
-  theme_ridges(center = TRUE) # center the x and y axis labels
+     features = c("olig2"), # feature(s) of interest
+     group.by = "default_clusters_res_0_1", # custom annotation set
+     cols = custom_palettes$default_clusters_res_0_1
+) + # custom color palette
+     labs(
+          title = "Expression of olig2", # update plot title
+          y = "Default clusters - res. 0.1"
+     ) + # update x-axis label
+     theme_ridges(center = TRUE) # center the x and y axis labels
 ```
 
 <img src="https://cdn.bfldr.com/2Q1IPX6I/at/283m8qq88ns5nqf5gt5wv37x/scrnaseq_vignette_ridgeplot_example" height="450">
@@ -191,12 +206,15 @@ Using the `Seurat` `FeaturePlot()` function, make a scatter plot in UMAP space c
 
 ```{r, eval = FALSE}
 FeaturePlot(so, # the Seurat object
-            features = c("olig2"), # feature(s) of interest
-            reduction = "umap", # could also be "tsne" or "pca"
-            pt.size = 0.1) + # point size for plotting
-  labs(title = "Expression of olig2", # update plot title
-       x = "UMAP 1", # update x-axis label
-       y = "UMAP 2") # update y-axis label
+     features = c("olig2"), # feature(s) of interest
+     reduction = "umap", # could also be "tsne" or "pca"
+     pt.size = 0.1
+) + # point size for plotting
+     labs(
+          title = "Expression of olig2", # update plot title
+          x = "UMAP 1", # update x-axis label
+          y = "UMAP 2"
+     ) # update y-axis label
 ```
 
 <img src="https://cdn.bfldr.com/2Q1IPX6I/at/hksqknxt4tn3c9p4bq8x3t9/scrnaseq_vignette_featureplot_example" height="450">
@@ -207,11 +225,14 @@ Using the `Seurat` `DotPlot()` function, make a dot plot colored by feature expr
 
 ```{r, eval = FALSE}
 DotPlot(so, # the Seurat object
-        features = c("olig2", "sox19a", "gfap", "dlb", "nkx2.2a"), # feature(s) of interest
-        group.by = "default_clusters_res_0_1") + # custom annotation set
-  labs(title = "Key marker genes", # update plot title
-       x = "Genes", # update x-axis label
-       y = "Default clusters - res. 0.1") # update y-axis label
+     features = c("olig2", "sox19a", "gfap", "dlb", "nkx2.2a"), # feature(s) of interest
+     group.by = "default_clusters_res_0_1"
+) + # custom annotation set
+     labs(
+          title = "Key marker genes", # update plot title
+          x = "Genes", # update x-axis label
+          y = "Default clusters - res. 0.1"
+     ) # update y-axis label
 ```
 
 <img src="https://cdn.bfldr.com/2Q1IPX6I/at/x8h97bhq72mxqcqgrvbkkf5/scrnaseq_vignette_dotplot_example" height="450">


### PR DESCRIPTION
Previously, raw and final Seurat objects were downloaded using positional indexes returned from the response object using the Seurat endpoint (`/lab/experiments/{{EXPERIMENT_UUID}}/files/?data_type=seurat`), such that:

- `seurat_resp$seurat$items[[1]]$uuid` corresponded to the `raw` (`seurat_01_create_object.rds`) Seurat object
- `seurat_resp$seurat$items[[2]]$uuid` corresponded to the `final` (`seurat_06_refine_object.rds`) Seurat object

Based on the `seurat_type` param, either the `raw` or `final` Seurat object would be returned to the user.

However, with the new Seurat object upload feature, we had to update how we access the Seurat objects in the response object. We can't access them via positional index, as existing experiments with uploaded Seurat objects had a bug whereby the original object (`raw`) is in index `[[2]]` and the updated, Pluto-compatible Seurat object (`final`) is in index `[[1]]`.

As a solution, the `pluto_download_seurat_object` function was updated to access Seurat objects based off of name. Note that original Seurat objects that are uploaded by a user retain the file name that they were uploaded with (i.e., they are not renamed to `seurat_01_create_object.rds`), whereas the Pluto-compatible version is renamed to `seurat_06_refine_object.rds`.

So, if `seurat_type` is `final`, we can look for a Seurat object in the response named `seurat_06_refine_object.rds`. If `seurat_type` is `raw`, we are looking for the Seurat object that is not named `seurat_06_refine_object.rds`.

At this time, there should only ever be a max 2 Seurat objects per response, and there should only ever be a max of 1 Seurat obejct named `seurat_06_refine_object.rds`.

Outstanding TODOs:
* Consider the edge-case where a user downloads `seurat_06_refine_object.rds` from one experiment in Pluto and uploads it to a new experiment without changing the file name. Will address this in a future PR.